### PR TITLE
Physics no longer ignores configured default stability type

### DIFF
--- a/src/main/java/enviromine/trackers/properties/BlockProperties.java
+++ b/src/main/java/enviromine/trackers/properties/BlockProperties.java
@@ -190,7 +190,7 @@ public class BlockProperties implements SerialisableProperty, PropertyBase
 		float temperature = (float)config.get(category, BPName[6], 0.00).getDouble(0.00);
 		float airQuality = (float)config.get(category, BPName[7], 0.00).getDouble(0.00);
 		float sanity = (float)config.get(category, BPName[8], 0.00).getDouble(0.00);
-		String stability = config.get(category, BPName[9], "loose").getString();
+		String stability = config.get(category, BPName[9], EM_Settings.defaultStability).getString();
 		boolean slides = config.get(category, BPName[10], false).getBoolean(false);
 		boolean wetSlides = config.get(category, BPName[11], false).getBoolean(false);
 		String filename = config.getConfigFile().getName();

--- a/src/main/java/enviromine/utils/EnviroUtils.java
+++ b/src/main/java/enviromine/utils/EnviroUtils.java
@@ -244,7 +244,7 @@ public class EnviroUtils
 			type = EM_Settings.stabilityTypes.get("average");
 		} else
 		{
-			type = EM_Settings.stabilityTypes.get("loose");
+			type = EM_Settings.stabilityTypes.get(EM_Settings.defaultStability);
 		}
 		
 		if(type == null)


### PR DESCRIPTION
Right now unconfigured blocks always default to "loose", despite the config option.  This fixes it to use the configured default stability type.